### PR TITLE
Add `--compat-level` option to conda index

### DIFF
--- a/cep-9999.md
+++ b/cep-9999.md
@@ -1,0 +1,63 @@
+<table>
+<tr><td> Title </td><td> Introduce `--compat-level` option to `conda index` </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Cheng H. Lee &lt;clee@anaconda.com&gt; </td></tr>
+<tr><td> Created </td><td> 2021-09-23 </td></tr>
+<tr><td> Updated </td><td> 2021-09-23 </td></tr>
+<tr><td> Discussion </td><td> NA </td></tr>
+<tr><td> Implementation </td><td> To be implemented </td></tr>
+</table>
+
+## Abstract
+
+Introduce a `--compat-level` option to `conda-index`
+
+
+## Motivation
+
+Conda-build 3.20.5 introduced support for the PEP-440 "compatible release"
+operator (`~=`) in package requirement specifications (AKA MatchSpecs).  A
+major consequence of this change is that recent versions of `conda index` may
+generate repository index (`repodata.json`) files that include this operator,
+which render channels containing these indices incompatible with older
+(pre-4.9.1) releases.  This incompatibility is especially of concern to larger
+channels, such Anaconda's defaults and conda-forge, that use the latest
+conda-build in their package build process but still need to support a
+significant user base using older conda releases.
+
+To resolve this compatibility issue, we propose adding a `--compat-level=x.y`
+option to `conda index`, which would require the output `repodata.json` to be
+compatible with conda x.y.
+
+
+## Implementation
+
+* Add `--compat-level` option
+* Set `--compat-level=4.9` to include expansion of `~=V.N` to `>=V.N,==V.*`
+
+
+## Rationale
+
+
+Alternatives that were considered:
+
+* Make no changes to `conda index` and leave it up channel maintainers to use
+  the existing repodata patching.  Rejected because this puts unnecessary
+  burden on package and channel maintainers.
+
+* Directly implement the change in `conda index` without adding a new option;
+  i.e., have `conda index` always expand `~=V.N` to `>=V.N,==V.*`.  Potentially
+  imposes backwards compatibility on users who may not need them.  Does not
+  establish pattern for changing compatibility.
+
+
+## References
+
+* [conda-build 3.20.5 release notes](https://github.com/conda/conda-build/releases/tag/3.20.5)
+* [conda 4.9.1 release notes](https://github.com/conda/conda/releases/tag/4.9.1)
+* [PEP 440: compatible release operator](https://www.python.org/dev/peps/pep-0440/#compatible-release)
+
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This CEP would add an option to conda index to get it to generate repodata.json files that are compatible with older conda releases.