### PR TITLE
Automate adding issues and PRs to the CEP project.

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,18 @@
+name: Add to Project
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.0.4
+        with:
+          project-url: https://github.com/orgs/conda-incubator/projects/1
+          github-token: ${{ secrets.CEPS_PROJECT_TOKEN }}


### PR DESCRIPTION
This follows the same patterns that were used for the new GitHub project for the conda org: https://github.com/conda/infra/pull/550