### PR TITLE
Added conda capitalization standard to CEP docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ A template for new CEPs is given in [CEP 0](https://github.com/conda/ceps/blob/m
 
 ## Conda capitalization standards
 
-Conda should be written in lowercase, whether in reference to the tool, ecosystem, packages, or organization. References to the conda command should use code formatting (i.e. `conda`). If the use of conda is not a command and if conda is at the beginning of a sentence, conda should be uppercase.
+1. Conda should be written in lowercase, whether in reference to the tool, ecosystem, packages, or organization.
+2. References to the conda command should use code formatting (i.e. `conda`).
+3. If the use of conda is not a command and if conda is at the beginning of a sentence, conda should be uppercase.
 
 ### Examples
 
@@ -45,4 +47,4 @@ Titles and headers should use the same capitalization and formmating standards a
 
 #### In links
 
-Links should use the same capitalization conventions as sentences. Because the conda docs currently used re-structured text (RST) as a markup language, and [RST does not support nested inline markup](https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible), documentation writers should avoid using code backtick formatting inside links.
+Links should use the same capitalization conventions as sentences. Because the conda docs currently use re-structured text (RST) as a markup language, and [RST does not support nested inline markup](https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible), documentation writers should avoid using code backtick formatting inside links.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ The formal process by which CEPs should be authored and how they are reviewed
 and resolved is specified in [CEP 1](https://github.com/conda/ceps/blob/main/cep-1.md).
 
 A template for new CEPs is given in [CEP 0](https://github.com/conda/ceps/blob/main/cep-0.md).
+
+## Conda capitalization standards
+
+Conda should be written in lowercase, whether in reference to the tool, ecosystem, packages, or organization. References to the conda command should use code formatting (i.e. `conda`). If the use of conda is not a command and if conda is at the beginning of a sentence, conda should be uppercase.
+
+### Examples
+
+#### In sentences
+
+Beginning a sentence: 
+
+- Conda is an open-source package and environment management system. 
+- `conda install` can be used to install packages.
+
+Conda in the middle of a sentence: 
+
+- If a newer version of conda is available, you can use `conda update conda` to update to that version.
+- You can find conda packages within conda channels. The `conda` command can search these channels.
+
+#### In titles and headers
+
+Titles and headers should use the same capitalization and formmating standards as sentences.
+
+#### In links
+
+Links should use the same capitalization conventions as sentences. Because the conda docs currently used re-structured text (RST) as a markup language, and [RST does not support nested inline markup](https://docutils.sourceforge.io/FAQ.html#is-nested-inline-markup-possible), documentation writers should avoid using code backtick formatting inside links.

--- a/cep-1.md
+++ b/cep-1.md
@@ -3,7 +3,7 @@
 <tr><td> Status </td><td> Proposed </td></tr>
 <tr><td> Author(s) </td><td> Jannis Leidel &lt;jleidel@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Jun 29, 2021</td></tr>
-<tr><td> Updated </td><td> Jun 29, 2021</td></tr>
+<tr><td> Updated </td><td> Aug 9 2022</td></tr>
 <tr><td> Discussion </td><td> NA </td></tr>
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
@@ -128,6 +128,10 @@ A final **copyright** section is also required.
 CEP is to be pronounced `/sep/`.
 
 If you still have doubts about how to actually pronounce it, here is a reference (we accept UK and US pronunciations): https://dictionary.cambridge.org/dictionary/english/cep
+
+## Conda capitalization standards
+
+For the capitalization standards for conda, see the [README](https://github.com/conda-incubator/ceps/blob/main/README.md).
 
 ## References
 


### PR DESCRIPTION
Closes #34.

Initially, we thought it would be good to add this information to CEP0, but since that is the blank CEP that everyone uses as an outline, it seemed better to add the standard to the README and then link to that from CEP 1, which contains the major rules for creating CEPs from CEP0.

Happy to discuss what would be better, though.