### PR TITLE
Conda Generic Plugin Hooks

### DIFF
--- a/new-cep.md
+++ b/new-cep.md
@@ -11,9 +11,11 @@
 ## Abstract
 
 In order to support a variety use cases and extensions to conda's default
-behavior, we propose a set of generic plugin hooks in this CEP. Included will be pre-run and post-run hooks that will allow
+behavior, we propose a set of generic plugin hooks in this CEP. Included will be `pre_run` and `post_run` hooks that will allow
 authors to execute their plugin code before or after conda commands
-run, respectively. We outline several example cases in this CEP and
+run, respectively. Additionally, we introduce the `on_exception` plugin 
+hook that will allow authors to execute when an exception is thrown. 
+For each hook, we outline example cases and
 show exactly how plugin authors will define these new hooks.
 
 ## Specification

--- a/new-cep.md
+++ b/new-cep.md
@@ -1,0 +1,39 @@
+<table>
+  <tr><td> Title </td><td> Conda Generic Plugin Hooks</td>
+  <tr><td> Status </td><td> Draft </td></tr>
+  <tr><td> Author(s) </td><td> Full Name &lt;thathaway@anaconda.com&gt;</td></tr>
+  <tr><td> Created </td><td> Dec 22, 2022</td></tr>
+  <tr><td> Updated </td><td> Dec 22, 2022</td></tr>
+  <tr><td> Discussion </td><td> _TBD_ </td></tr>
+  <tr><td> Implementation </td><td> _TBD_ </td></tr>
+</table>
+
+## Abstract
+
+In order to support a variety use cases and extensions to conda's default
+behavior, we propose a set of generic plugin hooks in this CEP. Included will be pre-run and post-run hooks that will allow
+authors to execute their plugin code before or after conda commands
+run, respectively. We outline several example cases in this CEP and
+show exactly how plugin authors will define these new hooks.
+
+## Specification
+
+## Motivation
+
+## Rationale
+
+## Sample Implementation
+
+_Point to the basic authentication example pull request._
+
+## FAQ
+
+## Resolution
+
+_TBD_
+
+## References
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This is a CEP for implementing a set of generic plugin hooks for conda. Included so far are the following hooks:

- **pre_run**: allows plugin authors to execute code before a command is run in the conda context
- **post_run**: allows plugin authors to execute code after a command is run in the conda context
- **on_execption**: allows plugin authors to execute code when an exception is thrown in conda

☝️ This list is not final, and we welcome a healthy discussion to debate exactly what belongs here.