### PR TITLE
Conda-build Release Schedule

### DIFF
--- a/cep-8.md
+++ b/cep-8.md
@@ -9,17 +9,23 @@
 <tr><td> Implementation </td><td> NA </td></tr>
 </table>
 
+<!-- links -->
+[cep9]: https://github.com/conda-incubator/ceps/blob/main/cep-9.md]
+[calver]: https://calver.org/
+[pep602]: https://peps.python.org/pep-0602/
+[django]: https://docs.djangoproject.com/en/dev/internals/release-process/#release-cadence
+
 ## Abstract
 
 This CEP describes a release cadence for all future `conda` versions starting with `22.9.0`.
 
 ## Specification
 
-We propose regularly scheduled bi-monthly (every two months) releases where the tagging/release occurs during the week (per ISO 8601, Monday through Thursday) of the second Monday of the month.
+We propose regularly scheduled bi-monthly (every two months) releases where the tagging/release occurs during the week (per ISO 8601, Monday through Thursday) of the **second** Monday of the month.
 
-In a nod to our many different kinds of users, we will also propose a deprecation policy (to be defined in a later CEP) that allows for a slower adoption rate (i.e., users could update every 3-4 months instead).
+In a nod to our many different kinds of users, we will also propose a deprecation policy ([CEP-9][cep9]) that allows for a slower adoption rate (i.e., users could update every 3-4 months instead).
 
-To accomplish better, more predictable versioning, we will adopt [CalVer](https://calver.org/):
+To accomplish better, more predictable versioning, we will adopt [CalVer][calver]:
 - `YY`: the major version will be the shortened year (22+)
 - `MM`: the minor version will be the shortened month (1-12)
 - `MICRO`: the micro/patch version is reset to zero every month and incremented for every additional release that occurs during that month (0+)
@@ -99,8 +105,8 @@ It should be noted that a request for change was recorded in the pull request ab
 
 ## Reference
 
-- [PEP 602 – Annual Release Cycle for Python](https://peps.python.org/pep-0602/)
-- [Django's Release Cadence](https://docs.djangoproject.com/en/dev/internals/release-process/#release-cadence)
+- [PEP 602 – Annual Release Cycle for Python][pep602]
+- [Django's Release Cadence][django]
 
 ## Copyright
 

--- a/cep-9.md
+++ b/cep-9.md
@@ -12,13 +12,14 @@
 [cep8]: https://github.com/conda-incubator/ceps/blob/main/cep-8.md
 [django]: https://docs.djangoproject.com/en/dev/internals/release-process/#deprecation-policy
 [voting]: https://github.com/conda-incubator/governance#enhancement-proposal-approval
+[cep9999]: https://github.com/conda-incubator/ceps/blob/main/cep-9999.md
 
 ## Abstract
 
 This CEP describes a deprecation schedule to properly warn about upcoming removals from the codebase. This policy expands on ideas and terminology defined in the [Conda Release Schedule (CEP-8)][cep8].
 
 > **Note**
-> This CEP is only applicable for projects that have adopted the [Conda Release Schedule (CEP-8)][cep8].
+> This CEP is only applicable for projects that have adopted either the [Conda Release Schedule (CEP-8)][cep8] or the [Conda-build Release Schedule (CEP-9999)][cep9999].
 
 ## Specification
 

--- a/cep-9999.md
+++ b/cep-9999.md
@@ -1,0 +1,99 @@
+<table>
+<tr><td> Title </td><td> Conda-build Release Schedule </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td>
+<td> Ken Odegard &lt;kodegard@anaconda.com&gt; </td></tr>
+<tr><td> Created </td><td> March 3, 2023 </td></tr>
+<tr><td> Updated </td><td> March 3, 2023 </td></tr>
+<tr><td> Discussion </td><td> TBD </td></tr>
+<tr><td> Implementation </td><td> NA </td></tr>
+</table>
+
+<!-- links -->
+[cep8]: https://github.com/conda-incubator/ceps/blob/main/cep-8.md
+[cep9]: https://github.com/conda-incubator/ceps/blob/main/cep-9.md
+[calver]: https://calver.org/
+[pep602]: https://peps.python.org/pep-0602/
+[django]: https://docs.djangoproject.com/en/dev/internals/release-process/#release-cadence
+
+## Abstract
+
+This CEP describes a release cadence for all future `conda-build` versions starting with `23.3.0`.
+
+## Specification
+
+We propose regularly scheduled bi-annual (every six months) releases where the tagging/release occurs during the week (per ISO 8601, Monday through Thursday) of the **third** Monday of the month (i.e., a week after the `conda` release of the same month).
+
+In adopting this release schedule we will also conform to the Deprecation Policy defined in [CEP-9][cep9].
+
+To accomplish better, more predictable versioning, we will adopt [CalVer][calver]:
+- `YY`: the major version will be the shortened year (22+)
+- `MM`: the minor version will be the shortened month (1-12)
+- `MICRO`: the micro/patch version is reset to zero every month and incremented for every additional release that occurs during that month (0+)
+
+This scheme will start with the March 2023 release of 23.3.0, resulting in the following regular release schedule:
+
+| Version | Release Week |
+|---|---|
+| 23.3.0 | 2022-09-12 |
+| 23.9.0 | 2022-11-14 |
+| 24.3.0 | 2023-01-09 |
+| 24.9.0 | 2023-03-13 |
+| ... | ... |
+
+> **Note**
+> Despite following a bi-annual release schedule, we will permit releases to occur at any time between regular releases for hotfixes, security releases, or other high-priority changes that require immediate release.
+
+To distinguish between the bi-annual release schedule and other optional releases, we define the following release types:
+
+- **Regular release**: the regularly scheduled bi-annual release
+- **Optional release**: releases that may occur on alternating months from regular releases
+- **Hotfix release**: extra releases that may occur during any month to patch an earlier release of the same month (whether a regular or optional release)
+
+So, it's entirely feasible to see the following releases:
+
+| Version | Release Type |
+|---|---|
+| 23.9.0 | regular |
+| 23.9.1 | hotfix |
+| 23.9.2 | hotfix |
+| 23.10.0 | optional |
+| 23.10.1 | hotfix |
+| 23.12.0 | optional |
+| 23.12.1 | hotfix |
+| ... | ... |
+
+> **Note**
+> In case no or few significant changes have been made since the last release, the conda-build maintainer team may decide to skip a regular release, as long as the decision is made public and documented in the changelog.
+
+## Motivation
+
+Our goal with this CEP is to remove ambiguity/maintainer guesswork of when and what warrants a release and to also provide a means by which we can adopt the Deprecation Policy ([CEP-9][cep9]) for conda-build.
+
+## Backwards Compatibility
+
+Adopting this release schedule does not break any existing processes or schemes.
+
+Since `SemVer` is semantically interchangeable with `CalVer` and we propose switching from `conda-build 3.23.3` to `conda-build 23.3.0`, both version parsing and version ordering will be unaffected.
+
+## Alternatives
+
+1. Do nothing. Continue with ad hoc releases.
+    - Rejected for being too inconsistent and challenging for roadmap/planning/deprecation purposes.
+2. Follow Conda Release Schedule ([CEP-8][cep8]).
+    - Rejected for being too fast given the current pace of development.
+
+## Resolution
+
+TBD
+
+## Reference
+
+- [PEP 602 – Annual Release Cycle for Python][pep602]
+- [Django's Release Cadence][django]
+- [CEP 8 - Conda Release Schedule][cep8]
+- [CEP 9 - Conda Deprecation Schedule][cep9]
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cep-9999.md
+++ b/cep-9999.md
@@ -27,7 +27,7 @@ We propose regularly scheduled bi-annual (every six months) releases where the t
 In adopting this release schedule we will also conform to the Deprecation Policy defined in [CEP-9][cep9].
 
 To accomplish better, more predictable versioning, we will adopt [CalVer][calver]:
-- `YY`: the major version will be the shortened year (22+)
+- `YY`: the major version will be the shortened year (23+)
 - `MM`: the minor version will be the shortened month (1-12)
 - `MICRO`: the micro/patch version is reset to zero every month and incremented for every additional release that occurs during that month (0+)
 
@@ -35,32 +35,34 @@ This scheme will start with the March 2023 release of 23.3.0, resulting in the f
 
 | Version | Release Week |
 |---|---|
-| 23.3.0 | 2022-09-12 |
-| 23.9.0 | 2022-11-14 |
-| 24.3.0 | 2023-01-09 |
-| 24.9.0 | 2023-03-13 |
+| 23.3.0 | 2023-03-20 |
+| 23.9.0 | 2023-09-18 |
+| 24.3.0 | 2024-03-18 |
+| 24.9.0 | 2024-09-16 |
 | ... | ... |
 
 > **Note**
 > Despite following a bi-annual release schedule, we will permit releases to occur at any time between regular releases for hotfixes, security releases, or other high-priority changes that require immediate release.
 
-To distinguish between the bi-annual release schedule and other optional releases, we define the following release types:
+We carry over the release types defined in [CEP-8][cep8] and [CEP-9][cep9]:
 
-- **Regular release**: the regularly scheduled bi-annual release
-- **Optional release**: releases that may occur on alternating months from regular releases
-- **Hotfix release**: extra releases that may occur during any month to patch an earlier release of the same month (whether a regular or optional release)
+- **Regular release**
+- **Deprecation release**
+- **Optional release**
+- **Hotfix release**
 
 So, it's entirely feasible to see the following releases:
 
 | Version | Release Type |
 |---|---|
-| 23.9.0 | regular |
+| 23.9.0 | regular, deprecation |
 | 23.9.1 | hotfix |
 | 23.9.2 | hotfix |
 | 23.10.0 | optional |
 | 23.10.1 | hotfix |
 | 23.12.0 | optional |
 | 23.12.1 | hotfix |
+| 24.3.0 | regular, deprecation |
 | ... | ... |
 
 > **Note**


### PR DESCRIPTION
### Description

Apply a release schedule to conda-build inspired by CEP8 so we can follow CEP9.

I updated CEP8 and CEP9 to include appropriate links.

### Objectives

- regular releases
  - better feature planning
  - adopt the deprecation policy
- option to do hotfix/bugfix/security releases when needed
- a consistent and predictable release cadence
- trivial and obvious release management