### PR TITLE
base_url CEP

### DIFF
--- a/cep-15.md
+++ b/cep-15.md
@@ -3,8 +3,8 @@
 <tr><td> Status </td><td> Draft </td></tr>
 <tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
 <tr><td> Created </td><td> Aug 24, 2023</td></tr>
-<tr><td> Updated </td><td> Aug 24, 2023</td></tr>
-<tr><td> Discussion </td><td>  </td></tr>
+<tr><td> Updated </td><td> Jan 22, 2024</td></tr>
+<tr><td> Discussion </td><td> https://github.com/conda-incubator/ceps/pull/61 </td></tr>
 <tr><td> Implementation </td><td>  </td></tr>
 </table>
 

--- a/cep-base-url.md
+++ b/cep-base-url.md
@@ -25,7 +25,7 @@ A minimal `repodata.json` looks like this.
 ```
 {"info": {"subdir": "linux-64"},
  "packages": {},
- "packages.conda": {"package-name.conda":{...}},
+ "packages.conda": {"some-package-filename.conda":{...}},
  "removed": [],
  "repodata_version": 1}
 ```
@@ -35,12 +35,13 @@ Add `base_url` to the `info` object. Increment `repodata_version`.
 ```
 {"info": {"subdir": "...", "base_url":"https://repo.anaconda.com/repo/main/linux-64/"},
  "packages": {},
- "packages.conda": {"package-name.conda":{...}},
+ "packages.conda": {"some-package-filename.conda":{...}},
  "removed": [],
  "repodata_version": 2}
  ```
 
-Append `base_url` and `package-name.conda` when downloading a package.
+Prepend `base_url` to the package filename when composing a download URL for a package.
+For the example above the resulting download URL would be `https://repo.anaconda.com/repo/main/linux-64/some-package.conda`.
 
 `base_url` can be an absolute or a relative URL.
 

--- a/cep-base-url.md
+++ b/cep-base-url.md
@@ -1,0 +1,54 @@
+<table>
+<tr><td> Title </td><td> Hosting repodata.json and packages separately by adding a base_url property. </td>
+<tr><td> Status </td><td> Draft </td></tr>
+<tr><td> Author(s) </td><td> Daniel Holth &lt;dholth@anaconda.com&gt;</td></tr>
+<tr><td> Created </td><td> Aug 24, 2023</td></tr>
+<tr><td> Updated </td><td> Aug 24, 2023</td></tr>
+<tr><td> Discussion </td><td>  </td></tr>
+<tr><td> Implementation </td><td>  </td></tr>
+</table>
+
+## Abstract
+
+Conda packages need to be stored in the same directory as `repodata.json`.
+
+This can be inconvenient especially when using alternative `repodata.json` for
+the same set of packages. For example, a user might be interested in installing
+packages based on an older snapshot of the index data that points to packages
+from the original index. Or a user might want to subset `repodata.json` based on
+policy.
+
+## Specification
+
+A minimal `repodata.json` looks like this.
+
+```
+{"info": {"subdir": "linux-64"},
+ "packages": {},
+ "packages.conda": {"package-name.conda":{...}},
+ "removed": [],
+ "repodata_version": 1}
+```
+
+Add `base_url` to the `info` object. Increment `repodata_version`.
+
+```
+{"info": {"subdir": "...", "base_url":"https://repo.anaconda.com/repo/main/linux-64/"},
+ "packages": {},
+ "packages.conda": {"package-name.conda":{...}},
+ "removed": [],
+ "repodata_version": 2}
+ ```
+
+Append `base_url` and `package-name.conda` when downloading a package.
+
+`base_url` can be an absolute or a relative URL.
+
+In the absence of `base_url`, packages are loaded relative to the
+`repodata.json`. Index data without the new `base_url` will continue to have
+`"repodata_version": 1`, but index data including `base_url` will have
+`"repodata_version": 2`.
+
+## Copyright
+
+All CEPs are explicitly [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Allow repodata.json and packages to live in separate places.